### PR TITLE
1.0.1 rc1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+*.NavData

--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@ AdvancedGraphicImageRenderer
 ============================
 
 Advanced PrimeFaces Graphic Image renderer for dynamic content
+
+
+The 1.0.1 brach is meant to work against version 3.5 of eclipselink.
+This branchs is dervided from the 1.0.0 tag.
+It contains the same fixes that were added to the master branch namely:
+<ul>
+  <li> web-fragment.xml causing deployment problems on weblogic is refactored to not declare the listener since the container picks it up autoamtically and the namespaces are upgarded from j2ee
+  <li> The GraphicImageManager get a fix to a tmp/ file leakage where with each request a new empty tmp file would get created and the image would not be rendered (because the file would be empty)
+</ul>
+
+
+In addition, the 1.0.1 branch also fixes a bug in the renderer AdvancedGraphicImageRenderer, which with each page refresh would leak an empty image in the tmp folder because the RID would not be unique.
+

--- a/README.md
+++ b/README.md
@@ -15,3 +15,20 @@ It contains the same fixes that were added to the master branch namely:
 
 In addition, the 1.0.1 branch also fixes a bug in the renderer AdvancedGraphicImageRenderer, which with each page refresh would leak an empty image in the tmp folder because the RID would not be unique.
 
+
+<p> Release Candaidate Notes:
+This forked branch of the original 1.0.0 branch is meant to work agianst primefaces 3.5 and has the following fixes.
+
+<ul>
+<li>
+(1) Synchronization that was missing on the resource manager - very simple synchroniztaiton
+<li>(2) Buts the Resource Manager as serilizable
+<li>(3) Reviews the process of generate unique ids - not even in the HEAD release is the code reselient to page refresh leaking images of 0 bytes due to the stream being closed.
+<li>(4) Is reselient to browser cache by producing a new unique id in a pseudo deterministic way, meaning that when it makes sense to produce a new unique id a new unique id is produced and it will be an id that the browser has not yet sean safeguarding from cache issues
+<li>(5) fixes leaking file input sream on the resource handler tha twas not closing the stream
+<li>(6) is more light weith in terms of pyhsical space consumption in the temp folder as it attempts on the fly to delete the stale old image generated on a previous request when a new stream content is created for the renderer
+<li>(7) It enhances the concept of when the Renderer actually decides to go ahead with the advanced graphic rendering algorithm or to ignore it and delegate to the default primefaces implementation.  (e.g if the user tried to force advancade rendering to take place by puting in the new advanced rendering tag under p:graphicImage, the advanced algorithm would always be triggered. This might not be desirable if the p:grpahic image has a non trivial value expression such as
+#{empty someBean.imageStramedContent ? resource['image/myStaticResourceForNoImage.jpg'] : someBean.myStreamedContent} where the outcome of the VE can either be a static resource or a streamed content. In such a case we would prefer for primefaces defaul implementation to take over while the advanced graphic image is really meant to target only streamed content since we know the expression cannot be evaluated during the resource handler execution.
+
+</ul>
+

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>advanced-graphic-image</artifactId>
     <name>Advanced Graphic image renderer</name>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.0.1-SNAPSHOT</version>
 
     <properties>
         <primefaces.version>3.4.1</primefaces.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -29,7 +29,7 @@
     <version>1.0.1-SNAPSHOT</version>
 
     <properties>
-        <primefaces.version>3.4.1</primefaces.version>
+        <primefaces.version>3.5</primefaces.version>
         <myfaces.version>2.1.6</myfaces.version>
     </properties>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>advanced-graphic-image</artifactId>
     <name>Advanced Graphic image renderer</name>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1-RC1</version>
 
     <properties>
         <primefaces.version>3.5</primefaces.version>
@@ -52,6 +52,20 @@
                     <source>1.6</source>
                     <target>1.6</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <!--This plugin allows to run the example using mvn jetty:run -->

--- a/core/src/main/java/be/rubus/web/jsf/primefaces/AdvancedGraphicImageRenderer.java
+++ b/core/src/main/java/be/rubus/web/jsf/primefaces/AdvancedGraphicImageRenderer.java
@@ -88,7 +88,7 @@ public class AdvancedGraphicImageRenderer extends GraphicImageRenderer {
             // this work around implementation creates a uniqueId using the string hashcode based on the uiComponent
             // ClientId and value expression
             // the outcome should be deterministic and not create file leakage.
-            String id = String.format("%1$s_", image.getClientId(), image.getValueExpression("value")
+            String id = String.format("%1$s_%2$s", image.getClientId(), image.getValueExpression("value")
                     .getExpressionString());
             String rid = String.valueOf(id.hashCode());
 

--- a/core/src/main/java/be/rubus/web/jsf/primefaces/GraphicImageManager.java
+++ b/core/src/main/java/be/rubus/web/jsf/primefaces/GraphicImageManager.java
@@ -1,20 +1,20 @@
 /**
-  * Licensed to the Apache Software Foundation (ASF) under one
-  * or more contributor license agreements.  See the NOTICE file
-  * distributed with this work for additional information
-  * regarding copyright ownership.  The ASF licenses this file
-  * to you under the Apache License, Version 2.0 (the
-  * "License"); you may not use this file except in compliance
-  * with the License.  You may obtain a copy of the License at
-  *
-  *   http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the License is distributed on an
-  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  * KIND, either express or implied.  See the License for the
-  * specific language governing permissions and limitations
-  * under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package be.rubus.web.jsf.primefaces;
 
@@ -30,14 +30,14 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  */
@@ -45,74 +45,120 @@ import java.util.Map;
 @ManagedBean(name = "GraphicImageManager")
 public class GraphicImageManager implements HttpSessionBindingListener {
 
-	private Map<String, String> storedContent = new HashMap<String, String>();
+    private static final Logger LOGGER = Logger.getLogger(GraphicImageManager.class.getCanonicalName());
 
-	@Override
-	public void valueBound(HttpSessionBindingEvent event) {
-		// No action required
-	}
+    /**
+     * Contains dynamic graphic image files creates in the context of the current session.
+     */
+    private final Map<String, String> storedContent = new ConcurrentHashMap<String, String>();
 
-	@Override
-	public void valueUnbound(HttpSessionBindingEvent event) {
-		for (String tempFile : storedContent.values()) {
-			File f = new File(tempFile);
-			f.delete();
-		}
-	}
+    @Override
+    public void valueBound(HttpSessionBindingEvent event) {
+        // No action required
+    }
 
-	public void registerImage(StreamedContent content, String uniqueId) {
-		try {
-			File tempFile = File.createTempFile(uniqueId, "primefaces");
+    @Override
+    public void valueUnbound(HttpSessionBindingEvent event) {
+        for (String tempFile : storedContent.values()) {
+            File f = new File(tempFile);
+            f.delete();
+        }
+    }
 
-			storedContent.put(uniqueId, tempFile.getAbsolutePath());
+    /**
+     * During the rendering phase of p:graphic image for which the advanced graphic image feature is enabled the
+     * StreamedContent gets written to a temporary file in the OS tmp file folder. Finally, the uniqueId will be used to
+     * do a lookup of path to the temporary file to render the image requested.
+     *
+     * @param content
+     *            the primefaces streamed content for an image which should be written out to an OS temporary file.
+     * @param uniqueId
+     *            a unique id for the current user session and image access, used to create a new unique temp file
+     *
+     */
+    public void registerImage(StreamedContent content, String uniqueId) {
 
-			InputStream input = content.getStream();
-			OutputStream output = new FileOutputStream(tempFile);
-			// get a channel from the stream
-			final ReadableByteChannel inputChannel = Channels.newChannel(input);
-			final WritableByteChannel outputChannel = Channels.newChannel(output);
-			// copy the channels
-			fastChannelCopy(inputChannel, outputChannel);
-			// closing the channels
-			inputChannel.close();
-			outputChannel.close();
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-	}
+        // (1) Trivial scenario - there is nothing to be done here because
+        // the user is most likely doing a page refresh and the image already exists in a temp file location
+        if (storedContent.containsKey(uniqueId)) {
+            LOGGER.log(Level.FINEST,
+                    "The streamed content for uniqueId will not be saved to a new file since it already exists in the cache. UiqueId: "
+                            + uniqueId);
+            return;
+        }
 
+        // (2) The uniqueId is brand new one so the streamed cotent has not yet been closed
+        // and we can save the data to a temporary file.
+        ReadableByteChannel inputChannel = null;
+        WritableByteChannel outputChannel = null;
+        try {
+            File tempFile = File.createTempFile(uniqueId, "primefaces");
+            storedContent.put(uniqueId, tempFile.getAbsolutePath());
+            // get a channel from the stream
+            inputChannel = Channels.newChannel(content.getStream());
+            outputChannel = Channels.newChannel(new FileOutputStream(tempFile));
+            // copy the channels
+            fastChannelCopy(inputChannel, outputChannel);
+        } catch (IOException e) {
+            LOGGER.log(
+                    Level.SEVERE,
+                    "Unexpected error took place while attempting to save primefaces streamed content image to the temporary fold",
+                    e);
+        } finally {
+            // closing the channels
+            try {
+                if (inputChannel != null) {
+                    inputChannel.close();
+                }
+            } catch (Exception e) {
+                LOGGER.log(
+                        Level.SEVERE,
+                        "Unexpected error took place while attempting to close the input stream of the image to be saved into a temporary location",
+                        e);
+            }
+            try {
+                if (outputChannel != null) {
+                    outputChannel.close();
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE,
+                        "Unexpected error took place while attempting to close the output stream of the temp file", e);
+            }
+        }
+    }
 
-	public StreamedContent retrieveImage(String uniqueId) {
-		StreamedContent result = null;
-		String tempFile = storedContent.get(uniqueId);
-		if (tempFile != null) {
-			File f = new File(tempFile);
-			try {
-				result = new DefaultStreamedContent(new FileInputStream(f));
-			} catch (FileNotFoundException e) {
-				// FIXME
-				e.printStackTrace();
-			}
-		}
-		return result;
-	}
+    public StreamedContent retrieveImage(String uniqueId) {
+        StreamedContent result = null;
+        String tempFile = storedContent.get(uniqueId);
+        if (tempFile != null) {
+            File f = new File(tempFile);
+            try {
+                result = new DefaultStreamedContent(new FileInputStream(f));
+            } catch (FileNotFoundException e) {
+                // FIXME
+                e.printStackTrace();
+            }
+        }
+        return result;
+    }
 
-	private static void fastChannelCopy(final ReadableByteChannel src, final WritableByteChannel dest) throws IOException {
-		final ByteBuffer buffer = ByteBuffer.allocateDirect(16 * 1024);
-		while (src.read(buffer) != -1) {
-			// prepare the buffer to be drained
-			buffer.flip();
-			// write to the channel, may block
-			dest.write(buffer);
-			// If partial transfer, shift remainder down
-			// If buffer is empty, same as doing clear()
-			buffer.compact();
-		}
-		// EOF will leave buffer in fill state
-		buffer.flip();
-		// make sure the buffer is fully drained.
-		while (buffer.hasRemaining()) {
-			dest.write(buffer);
-		}
-	}
+    private static void fastChannelCopy(final ReadableByteChannel src, final WritableByteChannel dest)
+            throws IOException {
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(16 * 1024);
+        while (src.read(buffer) != -1) {
+            // prepare the buffer to be drained
+            buffer.flip();
+            // write to the channel, may block
+            dest.write(buffer);
+            // If partial transfer, shift remainder down
+            // If buffer is empty, same as doing clear()
+            buffer.compact();
+        }
+        // EOF will leave buffer in fill state
+        buffer.flip();
+        // make sure the buffer is fully drained.
+        while (buffer.hasRemaining()) {
+            dest.write(buffer);
+        }
+    }
 }

--- a/core/src/main/java/be/rubus/web/jsf/primefaces/GraphicImageUtil.java
+++ b/core/src/main/java/be/rubus/web/jsf/primefaces/GraphicImageUtil.java
@@ -1,23 +1,18 @@
 /**
-  * Licensed to the Apache Software Foundation (ASF) under one
-  * or more contributor license agreements.  See the NOTICE file
-  * distributed with this work for additional information
-  * regarding copyright ownership.  The ASF licenses this file
-  * to you under the Apache License, Version 2.0 (the
-  * "License"); you may not use this file except in compliance
-  * with the License.  You may obtain a copy of the License at
-  *
-  *   http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the License is distributed on an
-  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  * KIND, either express or implied.  See the License for the
-  * specific language governing permissions and limitations
-  * under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package be.rubus.web.jsf.primefaces;
 
+import java.io.InputStream;
 import javax.el.ELContext;
 import javax.el.ValueExpression;
 import javax.faces.context.FacesContext;
@@ -26,18 +21,38 @@ import javax.faces.context.FacesContext;
  */
 public class GraphicImageUtil {
 
-	public static GraphicImageManager retrieveManager(FacesContext context) {
-		ELContext eLContext = context.getELContext();
-		ValueExpression ve = context.getApplication().getExpressionFactory()
-				.createValueExpression(context.getELContext(), buildElForGraphicImageManager(), GraphicImageManager.class);
-		return (GraphicImageManager) ve.getValue(eLContext);
+    public static GraphicImageManager retrieveManager(FacesContext context) {
+        ELContext eLContext = context.getELContext();
+        ValueExpression ve = context
+                .getApplication()
+                .getExpressionFactory()
+                .createValueExpression(context.getELContext(), buildElForGraphicImageManager(),
+                        GraphicImageManager.class);
+        return (GraphicImageManager) ve.getValue(eLContext);
 
-	}
+    }
 
-	private static String buildElForGraphicImageManager() {
-		StringBuilder result = new StringBuilder();
-		result.append("#{").append(GraphicImageManager.class.getSimpleName()).append("}");
-		return result.toString();
+    private static String buildElForGraphicImageManager() {
+        StringBuilder result = new StringBuilder();
+        result.append("#{").append(GraphicImageManager.class.getSimpleName()).append("}");
+        return result.toString();
 
-	}
+    }
+
+    /**
+     * Determines if a given input stream has bytes available to be read.
+     *
+     * <P>
+     * Bytes availableThis normally happen during the first time a StreamContent is being rendered, or, otherwise, when
+     * a new image gets uploaded. On the scenario where, for example, the page is refreshed, the StreamContent will be
+     * closed and in such a scenario we would want to continue using the old tmp file image.
+     */
+    public static boolean isInputStreamAvailable(InputStream inputStream) {
+        try {
+            return inputStream.available() > 0;
+        } catch (Exception ignoreE) {
+            // The GraphicImageManager has closed the input stream for the tmp file
+            return false;
+        }
+    }
 }

--- a/core/src/main/java/be/rubus/web/jsf/primefaces/ImageResourceHandler.java
+++ b/core/src/main/java/be/rubus/web/jsf/primefaces/ImageResourceHandler.java
@@ -1,20 +1,20 @@
 /**
-  * Licensed to the Apache Software Foundation (ASF) under one
-  * or more contributor license agreements.  See the NOTICE file
-  * distributed with this work for additional information
-  * regarding copyright ownership.  The ASF licenses this file
-  * to you under the Apache License, Version 2.0 (the
-  * "License"); you may not use this file except in compliance
-  * with the License.  You may obtain a copy of the License at
-  *
-  *   http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the License is distributed on an
-  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  * KIND, either express or implied.  See the License for the
-  * specific language governing permissions and limitations
-  * under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package be.rubus.web.jsf.primefaces;
 
@@ -28,51 +28,79 @@ import javax.faces.context.FacesContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  */
 public class ImageResourceHandler extends ResourceHandlerWrapper {
 
-	private ResourceHandler wrapped;
+    private static final Logger LOGGER = Logger.getLogger(ImageResourceHandler.class.getCanonicalName());
+    private ResourceHandler wrapped;
 
-	public ImageResourceHandler(ResourceHandler original) {
-		this.wrapped = original;
-	}
+    public ImageResourceHandler(ResourceHandler original) {
+        this.wrapped = original;
+    }
 
-	@Override
-	public ResourceHandler getWrapped() {
-		return wrapped;
-	}
+    @Override
+    public ResourceHandler getWrapped() {
+        return wrapped;
+    }
 
-	@Override
-	public void handleResourceRequest(FacesContext context) throws IOException {
-		Map<String, String> params = context.getExternalContext().getRequestParameterMap();
-		String library = params.get("ln");
-		String dynamicContentId = params.get(Constants.DYNAMIC_CONTENT_PARAM);
+    @Override
+    public void handleResourceRequest(FacesContext context) throws IOException {
+        Map<String, String> params = context.getExternalContext().getRequestParameterMap();
+        String library = params.get("ln");
+        String dynamicContentId = params.get(Constants.DYNAMIC_CONTENT_PARAM);
 
-		if (dynamicContentId != null && library != null && library.equals("advancedPrimefaces")) {
-			GraphicImageManager graphicImageManager = GraphicImageUtil.retrieveManager(context);
-			StreamedContent streamedContent = graphicImageManager.retrieveImage(dynamicContentId);
+        if (dynamicContentId != null && library != null && library.equals("advancedPrimefaces")) {
+            GraphicImageManager graphicImageManager = GraphicImageUtil.retrieveManager(context);
+            StreamedContent streamedContent = graphicImageManager.retrieveImage(dynamicContentId);
 
-			ExternalContext externalContext = context.getExternalContext();
-			externalContext.setResponseStatus(200);
-			externalContext.setResponseContentType(streamedContent.getContentType());
+            try {
+                ExternalContext externalContext = context.getExternalContext();
+                externalContext.setResponseStatus(200);
+                externalContext.setResponseContentType(streamedContent.getContentType());
 
-			byte[] buffer = new byte[2048];
+                byte[] buffer = new byte[2048];
 
-			int length;
-			InputStream inputStream = streamedContent.getStream();
-			while ((length = (inputStream.read(buffer))) >= 0) {
-				externalContext.getResponseOutputStream().write(buffer, 0, length);
-			}
+                int length;
+                InputStream inputStream = streamedContent.getStream();
+                while ((length = (inputStream.read(buffer))) >= 0) {
+                    externalContext.getResponseOutputStream().write(buffer, 0, length);
+                }
 
-			externalContext.responseFlushBuffer();
-			context.responseComplete();
+                externalContext.responseFlushBuffer();
+                context.responseComplete();
+            } finally {
+                // ensures the JVM will not be keeping file handler for the tmp file
+                closeStreamContent(streamedContent);
+            }
 
-		} else {
-			getWrapped().handleResourceRequest(context);
-		}
+        } else {
+            // this is desirable path - we are not dealing with advanced graphic rendering and
+            // we allow the defualt primefaces implementation to take over
+            getWrapped().handleResourceRequest(context);
+        }
 
-	}
+    }
+
+    /**
+     * Ensure that we do not leave the java vm process keeping alive a file pointer the tmp file.
+     *
+     * @param streamedContent
+     *            a stream created to feed to the browser the tmp file
+     */
+    private void closeStreamContent(StreamedContent streamedContent) {
+        try {
+            if (streamedContent != null) {
+                streamedContent.getStream().close();
+            }
+        } catch (Exception e) {
+            LOGGER.log(
+                    Level.SEVERE,
+                    "Unexpected error took while attempting to close the streamed cotent of temporary file associated to the advanced graphic image renderer",
+                    e);
+        }
+    }
 }
-

--- a/core/src/main/resources/META-INF/web-fragment.xml
+++ b/core/src/main/resources/META-INF/web-fragment.xml
@@ -17,14 +17,17 @@
  * specific language governing permissions and limitations
  * under the License.
 -->
-<web-app id="Demo" version="3.0"
-         xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_3_0.xsd">
-
-
-    <listener>
+<web-fragment version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-fragment_3_0.xsd">
+    
+    <!--
+        THe following listener does not NEED to be declared:
+        REFERENCE: http://www.coderanch.com/how-to/java/DeclaringListeners
+        QUOTE:  
+            The main point is : Classes implementing interfaces other than HttpSessionBindingListener and HttpSessionActivationListener need to be declared in DD.             
+    -->
+    <!--listener>
         <description>HttpSessionBindingListener</description>
         <listener-class>be.rubus.web.jsf.primefaces.GraphicImageManager</listener-class>
-    </listener>
-
-</web-app>
+    </listener-->
+</web-fragment>


### PR DESCRIPTION
Hi,

I would like you to consider the changes i've checked in to the 1.0.1 branch.
Please, I've tested it under welogic 12.1.2 and glassfish 3.1.2.9 both JEE 6 containers.

I would appreciate if you could review the branch and hopefully take it over.
The branches has:
(1) Synchronization that was missing on the resource manager - very simple synchroniztaiton
(2) Buts the Resource Manager as serilizable
(3) Reviews the process of generate unique ids - not even in the HEAD release is the code reselient to page refresh leaking images of 0 bytes due to the stream being closed.
(4) Is reselient to browser cache by producing a new unique id in a pseudo deterministic way, meaning that when it makes sense to produce a new unique id a new unique id is produced and it will be an id that the browser has not yet sean safeguarding from cache issues
(5) fixes leaking file input sream on the resource handler tha twas not closing the stream
(6) is more light weith in terms of pyhsical space consumption in the temp folder as it attempts on the fly to delete the stale old image generated on a previous request when a new stream content is created for the renderer

Kindest regards,
Nuno.
